### PR TITLE
Wrap model after saving

### DIFF
--- a/js/data/model.js
+++ b/js/data/model.js
@@ -101,8 +101,13 @@ export class ModelStore extends Model {
         const isNew = this._id === undefined;
         const conditions = {};
         conditions[this.constructor.idName] = this.identifier;
-        if (isNew) await this.constructor.collection.create(this.model);
-        else await this.constructor.collection.findOneAndUpdate(conditions, this.model);
+        let model;
+        if (isNew) {
+            model = await this.constructor.collection.create(this.model);
+        } else {
+            model = await this.constructor.collection.findOneAndUpdate(conditions, this.model);
+        }
+        this.wrap(model);
         return this;
     }
 


### PR DESCRIPTION
Because we weren't applying the retrieved object from the store, chained operations wouldn't work. Example:

```js
const something = Something.niw();
something.uniqueField = 10;
something.save();
something.save();
```

This wouldn't work because the object in the 2nd save wouldn't have `_id` defined, therefore it would be treated as a new entry rather than an update.