### PR TITLE
Response empty headers fix

### DIFF
--- a/js/api/api.js
+++ b/js/api/api.js
@@ -143,7 +143,7 @@ export class API extends Observable {
 
     async _handleResponse(response, errorMessage = "Problem in request") {
         let result = null;
-        if (response.headers.get("content-type").toLowerCase().startsWith("application/json")) {
+        if (response.headers.get("content-type") && response.headers.get("content-type").toLowerCase().startsWith("application/json")) {
             result = await response.json();
         } else {
             result = await response.blob();

--- a/js/api/api.js
+++ b/js/api/api.js
@@ -143,7 +143,10 @@ export class API extends Observable {
 
     async _handleResponse(response, errorMessage = "Problem in request") {
         let result = null;
-        if (response.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+        if (
+            response.headers.get("content-type") &&
+            response.headers.get("content-type").toLowerCase().startsWith("application/json")
+        ) {
             result = await response.json();
         } else {
             result = await response.blob();

--- a/js/api/api.js
+++ b/js/api/api.js
@@ -143,7 +143,7 @@ export class API extends Observable {
 
     async _handleResponse(response, errorMessage = "Problem in request") {
         let result = null;
-        if (response.headers.get("content-type") && response.headers.get("content-type").toLowerCase().startsWith("application/json")) {
+        if (response.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
             result = await response.json();
         } else {
             result = await response.blob();


### PR DESCRIPTION
| - | - |
| --- | --- |
| Problem | When a response is sent without headers or without `content-type` headers defined, an error happens when accessing them (see image below where a delete request with empty response was made). |
| Decisions | Check if header exists. However, if we interpret the not defined `content-type` as an empty response, maybe a better solution would be to set the `result` as `empty string` instead of a `Blob`. |
| Error | <img width="1385" alt="Screenshot 2020-09-24 at 11 21 16" src="https://user-images.githubusercontent.com/25725586/94133750-f76e4e80-fe58-11ea-88a6-66782af8fc68.png"> |


