### PR TITLE
Add html content type

### DIFF
--- a/js/api/api.js
+++ b/js/api/api.js
@@ -145,6 +145,9 @@ export class API extends Observable {
         let result = null;
         if (response.headers.get("content-type").toLowerCase().startsWith("application/json")) {
             result = await response.json();
+        }
+        else if (response.headers.get("content-type").toLowerCase().startsWith("text/")) {
+            result = await response.text();
         } else {
             result = await response.blob();
         }

--- a/js/api/api.js
+++ b/js/api/api.js
@@ -143,10 +143,15 @@ export class API extends Observable {
 
     async _handleResponse(response, errorMessage = "Problem in request") {
         let result = null;
-        if (response.headers.get("content-type").toLowerCase().startsWith("application/json")) {
+        if (
+            response.headers.get("content-type") &&
+            response.headers.get("content-type").toLowerCase().startsWith("application/json")
+        ) {
             result = await response.json();
-        }
-        else if (response.headers.get("content-type").toLowerCase().startsWith("text/")) {
+        } else if (
+            response.headers.get("content-type") &&
+            response.headers.get("content-type").toLowerCase().startsWith("text/")
+        ) {
             result = await response.text();
         } else {
             result = await response.blob();

--- a/test/api/api.js
+++ b/test/api/api.js
@@ -33,6 +33,9 @@ describe("API", function() {
             });
             assert.deepStrictEqual(result.args, { hello: "world" });
             assert.strictEqual(result.headers.Hello, "world");
+
+            result = await api.get(httpbinUrl + "html");
+            assert.strictEqual(typeof result, "string");
         });
     });
     describe("#post()", function() {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Dependencies | https://github.com/hivesolutions/yonius/pull/17 |
| Decisions | Add text content-type handling to response when content-type is text (always starts with `text/`). This will simplify handling a repose for an HTML page. <br> Common MIME types reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types |
