### PR TITLE
Add base/main type declarations

### DIFF
--- a/types/base/index.d.ts
+++ b/types/base/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./main";

--- a/types/base/main.d.ts
+++ b/types/base/main.d.ts
@@ -1,0 +1,3 @@
+export declare function register(name: string, value: any): void;
+export declare function unregister(name: string): void;
+export declare function request(name: string): any;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,1 +1,2 @@
+export * from "./base";
 export * from "./util";


### PR DESCRIPTION
Couldn't add the type for all [main](https://github.com/hivesolutions/yonius/blob/master/js/base/main.js) functions due to https://github.com/hivesolutions/yonius/issues/19. Both `load` and `unload` were left out.