### PR TITLE
Type definitions for the HTTP basic methods from yonius

### DIFF
--- a/types/api/api.d.ts
+++ b/types/api/api.d.ts
@@ -1,9 +1,9 @@
 export declare class API {
     constructor(kwargs?: Record<string, unknown>)
-    get(url: string, options?: Record<string, unknown>): any
-    post(url: string, options?: Record<string, unknown>): any
-    put(url: string, options?: Record<string, unknown>): any
-    delete(url: string, options?: Record<string, unknown>): any
-    patch(url: string, options?: Record<string, unknown>): any
-    options(url: string, options?: Record<string, unknown>): any
+    get(url: string, options?: Record<string, unknown>): unknown
+    post(url: string, options?: Record<string, unknown>): unknown
+    put(url: string, options?: Record<string, unknown>): unknown
+    delete(url: string, options?: Record<string, unknown>): unknown
+    patch(url: string, options?: Record<string, unknown>): unknown
+    options(url: string, options?: Record<string, unknown>): unknown
 }

--- a/types/api/api.d.ts
+++ b/types/api/api.d.ts
@@ -10,10 +10,10 @@ export declare class API {
 
 type APIOptions = {
     params?: Record<string, unknown>,
-    headers?: Record<string, unknown>,
+    headers?: HeadersInit,
     kwargs?: Record<string, unknown>,
     handle?: boolean,
-    data?: unknown,
+    data?: BodyInit | JSON,
     dataJ?: JSON,
     dataM?: unknown,
 }

--- a/types/api/api.d.ts
+++ b/types/api/api.d.ts
@@ -1,9 +1,9 @@
 export declare class API {
     constructor(kwargs?: Record<string, unknown>)
-    async get(url: string, options?: Record<string, unknown>): any
-    async post(url: string, options?: Record<string, unknown>): any
-    async put(url: string, options?: Record<string, unknown>): any
-    async delete(url: string, options?: Record<string, unknown>): any
-    async patch(url: string, options?: Record<string, unknown>): any
-    async options(url: string, options?: Record<string, unknown>): any
+    get(url: string, options?: Record<string, unknown>): any
+    post(url: string, options?: Record<string, unknown>): any
+    put(url: string, options?: Record<string, unknown>): any
+    delete(url: string, options?: Record<string, unknown>): any
+    patch(url: string, options?: Record<string, unknown>): any
+    options(url: string, options?: Record<string, unknown>): any
 }

--- a/types/api/api.d.ts
+++ b/types/api/api.d.ts
@@ -1,9 +1,19 @@
 export declare class API {
     constructor(kwargs?: Record<string, unknown>)
-    get(url: string, options?: Record<string, unknown>): unknown
-    post(url: string, options?: Record<string, unknown>): unknown
-    put(url: string, options?: Record<string, unknown>): unknown
-    delete(url: string, options?: Record<string, unknown>): unknown
-    patch(url: string, options?: Record<string, unknown>): unknown
-    options(url: string, options?: Record<string, unknown>): unknown
+    get(url: string, options?: APIOptions): unknown
+    post(url: string, options?: APIOptions): unknown
+    put(url: string, options?: APIOptions): unknown
+    delete(url: string, options?: APIOptions): unknown
+    patch(url: string, options?: APIOptions): unknown
+    options(url: string, options?: APIOptions): unknown
+}
+
+type APIOptions = {
+    params?: Record<string, unknown>,
+    headers?: Record<string, unknown>,
+    kwargs?: Record<string, unknown>,
+    handle?: boolean,
+    data?: unknown,
+    dataJ?: JSON,
+    dataM?: unknown,
 }

--- a/types/api/api.d.ts
+++ b/types/api/api.d.ts
@@ -15,5 +15,5 @@ type APIOptions = {
     handle?: boolean,
     data?: BodyInit | JSON,
     dataJ?: JSON,
-    dataM?: unknown,
+    dataM?: Record<string, unknown>
 }

--- a/types/api/api.d.ts
+++ b/types/api/api.d.ts
@@ -1,9 +1,9 @@
 export declare class API {
-    constructor(kwargs?: object)
-    async get(url: string, options?: object): any
-    async post(url: string, options?: object): any
-    async put(url: string, options?: object): any
-    async delete(url: string, options?: object): any
-    async patch(url: string, options?: object): any
-    async options(url: string, options?: object): any
+    constructor(kwargs?: Record<string, unknown>)
+    async get(url: string, options?: Record<string, unknown>): any
+    async post(url: string, options?: Record<string, unknown>): any
+    async put(url: string, options?: Record<string, unknown>): any
+    async delete(url: string, options?: Record<string, unknown>): any
+    async patch(url: string, options?: Record<string, unknown>): any
+    async options(url: string, options?: Record<string, unknown>): any
 }

--- a/types/api/api.d.ts
+++ b/types/api/api.d.ts
@@ -1,0 +1,9 @@
+export declare class API {
+    constructor(kwargs?: object)
+    async get(url: string, options?: object): any
+    async post(url: string, options?: object): any
+    async put(url: string, options?: object): any
+    async delete(url: string, options?: object): any
+    async patch(url: string, options?: object): any
+    async options(url: string, options?: object): any
+}

--- a/types/api/index.d.ts
+++ b/types/api/index.d.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,4 @@
+export * from "./api";
 export * from "./base";
 export * from "./data";
 export * from "./util";


### PR DESCRIPTION
Type definitions for basic HTTP methods (`GET/POST/PUT/DELETE/PATCH`) from the `API` class from `yonius` to be used within `TypeScript`.