### PR TITLE
Allow not iterable sequence in yonius.all() validation

### DIFF
--- a/js/util/validation.js
+++ b/js/util/validation.js
@@ -153,6 +153,8 @@ export const stringEq = function(valueC, message = "Must be exactly %{1} charact
 
 export const all = function(validation) {
     const _validation = (sequence, ctx) => {
+        if (!Array.isArray(sequence)) return true;
+
         for (const value of sequence) {
             validation(value, ctx);
         }

--- a/js/util/validation.js
+++ b/js/util/validation.js
@@ -153,7 +153,7 @@ export const stringEq = function(valueC, message = "Must be exactly %{1} charact
 
 export const all = function(validation) {
     const _validation = (sequence, ctx) => {
-        if (!Array.isArray(sequence)) return true;
+        if (sequence === null) return true;
         for (const value of sequence) {
             validation(value, ctx);
         }

--- a/js/util/validation.js
+++ b/js/util/validation.js
@@ -154,7 +154,6 @@ export const stringEq = function(valueC, message = "Must be exactly %{1} charact
 export const all = function(validation) {
     const _validation = (sequence, ctx) => {
         if (!Array.isArray(sequence)) return true;
-
         for (const value of sequence) {
             validation(value, ctx);
         }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Avoid errors when passing non iterable values to such as `null` |
| Dependencies | -- |
| Decisions | Add check to immediately return if sequence is `null` |