### PR TITLE
fix: use instanceof instead of isArray

### DIFF
--- a/js/api/api.js
+++ b/js/api/api.js
@@ -185,7 +185,7 @@ export class API extends Observable {
 
                 if (
                     typeof value === "object" &&
-                    !Array.isArray(value) &&
+                    !(value instanceof Array) &&
                     value.constructor !== Uint8Array
                 ) {
                     const headerL = [];
@@ -196,7 +196,7 @@ export class API extends Observable {
                     }
                     value = data;
                     header = headerL.join("\r\n");
-                } else if (Array.isArray(value)) {
+                } else if (value instanceof Array) {
                     let name = null;
                     let contents = null;
                     let contentTypeD = null;


### PR DESCRIPTION
[`Array.isArray` and `instanceof Array` are different](https://stackoverflow.com/questions/22289727/difference-between-using-array-isarray-and-instanceof-array) and may produce different results. When trying to upload a filetuple, it was encoding it as an object instead of an array, since Array.isArray was resulting false instead of true.
SDKs method use `instanceof` and it was working, this problem was found by comparing the inner workings of where the value would go inside the function and check for differences. With these changes, the fileTuple encoding is correct

Reference to the fix in RIPE SDK https://github.com/ripe-tech/ripe-sdk/commit/0613e614c6c24b231ec16735aca7d6da38730f72