### PR TITLE
feat: equal date support

### DIFF
--- a/js/util/object.js
+++ b/js/util/object.js
@@ -11,6 +11,10 @@ export const equal = function(first, second) {
         return first === second;
     }
 
+    if (first instanceof Date && second instanceof Date) {
+        return first === second;
+    }
+
     if (Object.keys(first).length !== Object.keys(second).length) {
         return false;
     }

--- a/test/util/object.js
+++ b/test/util/object.js
@@ -1,0 +1,43 @@
+const assert = require("assert");
+const yonius = require("../..");
+
+describe("#equal()", function() {
+    it("should be able to verify that primitive values are equal", () => {
+        let result;
+
+        result = yonius.equal(1, 1);
+        assert.strictEqual(result, true);
+
+        result = yonius.equal(1, 2);
+        assert.strictEqual(result, false);
+
+        result = yonius.equal("string", "string");
+        assert.strictEqual(result, true);
+
+        result = yonius.equal("string", "unknown");
+        assert.strictEqual(result, false);
+    });
+
+    it("should be able to verify that date values are equal", () => {
+        let result;
+
+        result = yonius.equal(new Date(), new Date(2000, 1, 1));
+        console.log(new Date(), new Date(2000, 1, 1), result);
+        assert.strictEqual(result, false);
+
+        const date = new Date();
+        result = yonius.equal(date, date);
+        assert.strictEqual(result, true);
+    });
+
+    it("should be able to verify that object values are equal", () => {
+        const object = { id: 1, name: "name" };
+        let result;
+
+        result = yonius.equal(object, object);
+        assert.strictEqual(result, true);
+
+        result = yonius.equal(object, { id: 1 });
+        assert.strictEqual(result, false);
+    });
+});


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | From https://github.com/ripe-tech/ripe-id-mobile/pull/45 |
| Dependencies | -- |
| Decisions | Support for date comparison in `equal` method. (compares the date strings) |
| Animated GIF | -- |
