### PR TITLE
Add `fromArrayBuffer` and `fromBlob` to FileTuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add `fromArrayBuffer` and `fromBlob` to `FileTuple`
 
 ### Changed
 

--- a/js/base/struct.js
+++ b/js/base/struct.js
@@ -12,12 +12,12 @@ export class FileTuple extends Array {
     static fromArrayBuffer(arrayBuffer, name = null, mime = null) {
         const buffer = Buffer.from(arrayBuffer);
         return this.fromData(buffer, name, mime);
-    };
+    }
 
     static async fromBlob(blob, name = null, mime = null) {
         const arrayBuffer = await blob.arrayBuffer();
         return this.fromArrayBuffer(arrayBuffer, name, mime);
-    };
+    }
 
     get name() {
         return this[0];

--- a/js/base/struct.js
+++ b/js/base/struct.js
@@ -9,6 +9,16 @@ export class FileTuple extends Array {
         return this.fromData(data, name, mime);
     }
 
+    static fromArrayBuffer(arrayBuffer, name = null, mime = null) {
+        const buffer = Buffer.from(arrayBuffer);
+        return this.fromData(buffer, name, mime);
+    };
+
+    static async fromBlob(blob, name = null, mime = null) {
+        const arrayBuffer = await blob.arrayBuffer();
+        return this.fromArrayBuffer(arrayBuffer, name, mime);
+    };
+
     get name() {
         return this[0];
     }

--- a/test/base/struct.js
+++ b/test/base/struct.js
@@ -1,11 +1,63 @@
 const assert = require("assert");
 const yonius = require("../../");
 
+const { Blob } = require("buffer");
+
 describe("FileTuple", function() {
     describe("#fromData()", async function() {
         it("should be able to create a simple file tuple objects", () => {
             const fileTuple = yonius.FileTuple.fromData(
                 new Uint8Array(),
+                "hello.txt",
+                "text/plain"
+            );
+            assert.notStrictEqual(fileTuple, null);
+            assert.strictEqual(fileTuple.constructor, yonius.FileTuple);
+            assert.strictEqual(fileTuple.name, "hello.txt");
+            assert.strictEqual(fileTuple.mime, "text/plain");
+            assert.strictEqual(fileTuple.data.byteLength, 0);
+            assert.strictEqual(fileTuple instanceof yonius.FileTuple, true);
+            assert.strictEqual(fileTuple instanceof Array, true);
+            assert.strictEqual(Array.isArray(fileTuple), true);
+        });
+    });
+
+    describe("#fromString()", async function() {
+        it("should be able to create a simple file tuple objects", () => {
+            const fileTuple = yonius.FileTuple.fromString("hello", "hello.txt", "text/plain");
+            assert.notStrictEqual(fileTuple, null);
+            assert.strictEqual(fileTuple.constructor, yonius.FileTuple);
+            assert.strictEqual(fileTuple.name, "hello.txt");
+            assert.strictEqual(fileTuple.mime, "text/plain");
+            assert.strictEqual(fileTuple.data.byteLength, 5);
+            assert.strictEqual(fileTuple instanceof yonius.FileTuple, true);
+            assert.strictEqual(fileTuple instanceof Array, true);
+            assert.strictEqual(Array.isArray(fileTuple), true);
+        });
+    });
+
+    describe("#fromArrayBuffer()", async function() {
+        it("should be able to create a simple file tuple objects", () => {
+            const fileTuple = yonius.FileTuple.fromArrayBuffer(
+                new ArrayBuffer(),
+                "hello.txt",
+                "text/plain"
+            );
+            assert.notStrictEqual(fileTuple, null);
+            assert.strictEqual(fileTuple.constructor, yonius.FileTuple);
+            assert.strictEqual(fileTuple.name, "hello.txt");
+            assert.strictEqual(fileTuple.mime, "text/plain");
+            assert.strictEqual(fileTuple.data.byteLength, 0);
+            assert.strictEqual(fileTuple instanceof yonius.FileTuple, true);
+            assert.strictEqual(fileTuple instanceof Array, true);
+            assert.strictEqual(Array.isArray(fileTuple), true);
+        });
+    });
+
+    describe("#fromBlob()", async function() {
+        it("should be able to create a simple file tuple objects", async () => {
+            const fileTuple = await yonius.FileTuple.fromBlob(
+                new Blob(),
                 "hello.txt",
                 "text/plain"
             );

--- a/types/base/struct.d.ts
+++ b/types/base/struct.d.ts
@@ -1,6 +1,8 @@
 export declare class FileTuple extends Array {
     static fromData(data: Uint8Array, name?: string, mime?: string): FileTuple;
     static fromString(dataString: StringConstructor, name?: string, mime?: string): FileTuple;
+    static fromArrayBuffer(arrayBuffer: ArrayBuffer, name?: string, mime?: string): FileTuple;
+    static async fromBlob(blob: Blob, name?: string, mime?: string): FileTuple;
     get name(): string;
     get mime(): string;
     get data(): Uint8Array;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Suggestion made here: https://github.com/ripe-tech/hermes-proxy/pull/136#discussion_r871543807 (related to https://github.com/ripe-tech/hermes-proxy/issues/135) |
| Dependencies | -- |
| Decisions | • Add `fromArrayBuffer` and `fromBlob` to `FileTuple`<br>• Add tests: `#fromString()`, `#fromArrayBuffer()` and `#fromBlob()` |

**NOTE:** A port of these changes will be made in ripe-sdk 🚀

![imagem](https://user-images.githubusercontent.com/22588915/168309802-db6669c2-e3b4-4dcc-a799-60ed8aab09ed.png)

